### PR TITLE
Adding Title Metadata

### DIFF
--- a/_extensions/clean/typst-environment.lua
+++ b/_extensions/clean/typst-environment.lua
@@ -65,6 +65,13 @@ end
 local function readEnvsAndCommands(meta)
   readEnvironments(meta)
   readCommands(meta)
+  
+  -- Set default for show-slide-numbers if not defined
+  if meta['show-slide-numbers'] == nil then
+    meta['show-slide-numbers'] = true
+  end
+  
+  return meta
 end
 
 local function endTypstBlock(blocks)

--- a/_extensions/clean/typst-environment.lua
+++ b/_extensions/clean/typst-environment.lua
@@ -65,12 +65,6 @@ end
 local function readEnvsAndCommands(meta)
   readEnvironments(meta)
   readCommands(meta)
-  
-  -- Set default for show-slide-numbers if not defined
-  if meta['show-slide-numbers'] == nil then
-    meta['show-slide-numbers'] = true
-  end
-  
   return meta
 end
 

--- a/_extensions/clean/typst-show.typ
+++ b/_extensions/clean/typst-show.typ
@@ -3,6 +3,7 @@
   $if(handout)$
     handout: true,
   $endif$
+    show-slide-numbers: $show-slide-numbers$,
   // Typography ---------------------------------------------------------------
   $if(fontsize)$
     font-size: $fontsize$,

--- a/_extensions/clean/typst-show.typ
+++ b/_extensions/clean/typst-show.typ
@@ -3,7 +3,9 @@
   $if(handout)$
     handout: true,
   $endif$
-    show-slide-numbers: $show-slide-numbers$,
+  $if(hide-slide-numbers)$
+    hide-slide-numbers: true,
+  $endif$
   // Typography ---------------------------------------------------------------
   $if(fontsize)$
     font-size: $fontsize$,

--- a/_extensions/clean/typst-template.typ
+++ b/_extensions/clean/typst-template.typ
@@ -1,2 +1,2 @@
-#import "@preview/touying-quarto-clean:0.1.3": *
+#import "@preview/touying-quarto-clean:0.1.4": *
 

--- a/template-full.qmd
+++ b/template-full.qmd
@@ -13,6 +13,7 @@ format:
   clean-typst:
     bibliographystyle: "chicago-author-date"
     include-in-header: "custom.typ"
+    show-slide-numbers: true
     commands: [small-cite]
 execute: 
   echo: false
@@ -243,6 +244,7 @@ format:
   - `commands` in YAML is for inline elements `[]{.foo}`
 - `[text]{.foo options="opts"}` is converted to `#foo(opts)[text]` internally
 - If you want to use `self` as an argument, you can use `touying-fn-wrapper()`
+- Slide numbers can be removed by setting `show-slide-numbers: false`
 
 
 ## `brand.yml` Support
@@ -604,7 +606,7 @@ quarto install extension kazuyanagimoto/quarto-clean-typst
 
 ### Appendix
 
-- You can use `{{{< appendix >}}}` to start an appendix section. Slide numbering will be freezed. (Next Slides)
+- You can use `{{{< appendix >}}}` to start an appendix section. Slide numbering will be frozen. (Next Slides). 
 
 {{< appendix >}}
 

--- a/template-full.qmd
+++ b/template-full.qmd
@@ -13,7 +13,6 @@ format:
   clean-typst:
     bibliographystyle: "chicago-author-date"
     include-in-header: "custom.typ"
-    show-slide-numbers: true
     commands: [small-cite]
 execute: 
   echo: false
@@ -244,7 +243,7 @@ format:
   - `commands` in YAML is for inline elements `[]{.foo}`
 - `[text]{.foo options="opts"}` is converted to `#foo(opts)[text]` internally
 - If you want to use `self` as an argument, you can use `touying-fn-wrapper()`
-- Slide numbers can be removed by setting `show-slide-numbers: false`
+- Slide numbers can be removed by setting `hide-slide-numbers: true`
 
 
 ## `brand.yml` Support

--- a/touying-quarto-clean/lib.typ
+++ b/touying-quarto-clean/lib.typ
@@ -35,7 +35,7 @@
     show: pad.with(.4em)
     set text(fill: self.colors.neutral-darkest, size: .8em)
     utils.call-or-display(self, self.store.footer)
-    if self.store.at("show-slide-numbers", default: true) {
+    if not self.store.at("hide-slide-numbers", default: false) {
       h(1fr)
       context utils.slide-counter.display() + " / " + utils.last-slide-number
     }
@@ -55,7 +55,7 @@
   handout: false,
   header: utils.display-current-heading(level: 2),
   footer: [],
-  show-slide-numbers: true,
+  hide-slide-numbers: false,
   font-size: 20pt,
   font-family-heading: "Roboto",
   font-family-body: "Roboto",
@@ -136,7 +136,7 @@
     config-store(
       header: header,
       footer: footer,
-      show-slide-numbers: show-slide-numbers,
+      hide-slide-numbers: hide-slide-numbers,
       font-family-heading: font-family-heading,
       font-family-body: font-family-body,
       font-size-title: font-size-title,

--- a/touying-quarto-clean/lib.typ
+++ b/touying-quarto-clean/lib.typ
@@ -35,8 +35,10 @@
     show: pad.with(.4em)
     set text(fill: self.colors.neutral-darkest, size: .8em)
     utils.call-or-display(self, self.store.footer)
-    h(1fr)
-    context utils.slide-counter.display() + " / " + utils.last-slide-number
+    if self.store.at("show-slide-numbers", default: true) {
+      h(1fr)
+      context utils.slide-counter.display() + " / " + utils.last-slide-number
+    }
   }
 
   // Set the slide
@@ -53,6 +55,7 @@
   handout: false,
   header: utils.display-current-heading(level: 2),
   footer: [],
+  show-slide-numbers: true,
   font-size: 20pt,
   font-family-heading: "Roboto",
   font-family-body: "Roboto",
@@ -133,6 +136,7 @@
     config-store(
       header: header,
       footer: footer,
+      show-slide-numbers: show-slide-numbers,
       font-family-heading: font-family-heading,
       font-family-body: font-family-body,
       font-size-title: font-size-title,

--- a/touying-quarto-clean/lib.typ
+++ b/touying-quarto-clean/lib.typ
@@ -155,6 +155,9 @@
   ..args,
 ) = touying-slide-wrapper(self => {
   let info = self.info + args.named()
+
+  set document(title: info.title)
+
   let body = {
     set align(left + horizon)
     block(inset: (y: 1em), [#text(

--- a/touying-quarto-clean/template/main.typ
+++ b/touying-quarto-clean/template/main.typ
@@ -1,6 +1,4 @@
-#import "@preview/touying-quarto-clean:0.1.3": *
-
-#show: clean-theme.with()
+#import "@preview/touying-quarto-clean:0.1.4": *
 
 #title-slide(
   title: [A title],

--- a/touying-quarto-clean/typst.toml
+++ b/touying-quarto-clean/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "touying-quarto-clean"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Kazuharu Yanagimoto <kazuharu.yanagimoto@gmail.com>"]
 license = "MIT"
 entrypoint = "lib.typ"


### PR DESCRIPTION
I noticed that the title isn't being added to the PDF metadata. This is important for accessibility (or at least important for my university's accessibility checker). This does that.

I tried to do the same with authors, but I think there are some issues caused by it being content. The typst maintainer decided to let titles be passed as content but not authors (from what I can understand from this thread: https://github.com/typst/typst/issues/2196 ) 

I tried to create this as separate from the other pull request but not sure if that really worked. 